### PR TITLE
Handling wrong packet

### DIFF
--- a/src/NetMQ/Core/Transports/V1Decoder.cs
+++ b/src/NetMQ/Core/Transports/V1Decoder.cs
@@ -144,7 +144,7 @@ namespace NetMQ.Core.Transports
             long payloadLength = m_tmpbuf.GetLong(Endian, 0);
 
             // There has to be at least one byte (the flags) in the message).
-            if (payloadLength == 0)
+            if (payloadLength <= 0)
             {
                 DecodingError();
                 return false;


### PR DESCRIPTION
Having router socket binded to port x.
Obtain packet sender from https://packetsender.com/ or something similar
Use the packet sender and send packet with following hex value: ff ff ff ff ff ff ff ff e2 aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa 
to port x
This results in:
System.OverflowException: Array dimensions exceeded supported range.
at NetMQ.GCBufferPool.Take(Int32 size)
at NetMQ.Msg.InitPool(Int32 size)
at NetMQ.Core.Transports.V1Decoder.EightByteSizeReady()
at NetMQ.Core.Transports.DecoderBase.ProcessBuffer(ByteArraySegment data, Int32 size)
at NetMQ.Core.Transports.StreamEngine.ProcessInput()
and this crashes whole application.

This can be triggered for example by security scanner (that's how we learned)
