### PR TITLE
Fix initial PGM Publisher Bind Exception handling

### DIFF
--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using AsyncIO;
 using JetBrains.Annotations;
@@ -683,6 +684,27 @@ namespace NetMQ.Core
                         }
                         paddr.Resolved = new PgmAddress();
                         paddr.Resolved.Resolve(address, m_options.IPv4Only);
+
+                        //Force a PGM Publisher Bind Exception to escalate here and not in a child thread. 
+                        var pgmAdr = (PgmAddress)paddr.Resolved;
+                        if (pgmAdr.InterfaceAddress != null)
+                        {
+                            AsyncSocket dummySocket = AsyncSocket.Create(AddressFamily.InterNetwork,
+                                SocketType.Dgram, ProtocolType.Udp);
+                            try
+                            {
+                                dummySocket.Bind(IPAddress.Parse(pgmAdr.InterfaceAddress.ToString()), 0);
+                            }
+                            catch (SocketException ex)
+                            {
+                                throw NetMQException.Create(ex.SocketErrorCode, ex);
+                            }
+                            finally
+                            {
+                                dummySocket.Dispose();
+                            }
+                        }
+
                         break;
                     }
             }


### PR DESCRIPTION
A bound PGM Pubslisher -e.g. pub.Connect("pgm://172.16.1.1;239.0.0.200:5554")- crashes with an SocketException in Async.IO ("An invalid Argument was supplied") in a child thread, when the NIC is disabled or enabled but never had a cable plugged in. This fix forces to check if a bind is possible by using a dummy socket. If an Exception is thrown it can now be handled and catched in the calling thread. In doing so, the Publisher coincides with the initial bind exception handling of the Subscriber.

